### PR TITLE
Add G-Force to API and Chart

### DIFF
--- a/Telemachus/src/DataLinkHandlers.cs
+++ b/Telemachus/src/DataLinkHandlers.cs
@@ -1186,6 +1186,9 @@ namespace Telemachus
                 dataSources => { return dataSources.vessel.verticalSpeed; },
                 "v.verticalSpeed", "Vertical Speed", formatters.Default, APIEntry.UnitType.VELOCITY));
             registerAPI(new PlotableAPIEntry(
+                dataSources => { return dataSources.vessel.geeForce; },
+                "v.geeForce", "G-Force", formatters.Default, APIEntry.UnitType.G));
+            registerAPI(new PlotableAPIEntry(
                 dataSources => { return dataSources.vessel.atmDensity; },
                 "v.atmosphericDensity", "Atmospheric Density", formatters.Default, APIEntry.UnitType.UNITLESS));
             registerAPI(new PlotableAPIEntry(

--- a/WebPages/WebPages/src/console.js
+++ b/WebPages/WebPages/src/console.js
@@ -40,7 +40,16 @@
         max: null
       }
     },
-    "G-Force": {
+	"Vessel G-Force": {
+      series: ["v.geeForce"],
+      yaxis: {
+        label: "Acceleration",
+        unit: "Gs",
+        min: null,
+        max: null
+      }
+    },
+    "Sensor G-Force": {
       series: ["s.sensor.acc"],
       yaxis: {
         label: "Acceleration",


### PR DESCRIPTION
# What is it?

This PR simply adds `v.geeForce` to the API, to allow monitoring the acceleration of your vessel. It is also displayable in the charts of the console-window.
## Changes
- add `v.geeForce` to API
- rename chart-element **G-Force** to **Sensor G-Force**
- add chart-element **Vessel G-Force** (based on `v.geeForce`)
