### PR TITLE
Fix issue #16: use inverseStage instead of inStageIndex: Staging.current...

### DIFF
--- a/Telemachus/src/DataLinkFormatters.cs
+++ b/Telemachus/src/DataLinkFormatters.cs
@@ -214,7 +214,7 @@ namespace Telemachus
 
                     foreach (PartResource p in resources)
                     {
-                        if (p.part.inStageIndex == Staging.CurrentStage)
+                        if (p.part.inverseStage == Staging.CurrentStage)
                         {
                             amount += p.amount;
                         }


### PR DESCRIPTION
This fixes issue #16 (current resource is always 0).

Staging.CurrentStage contains the stage index as shown in the UI (from N to 0) and the Part.inStageIndex is actually -1 or 0, but never matches a stage index. The fix is to use Part.inverseStage.
