### PR TITLE
Issue #20: Extended JSON regex for whitespace

### DIFF
--- a/Telemachus/src/KSPWebSocketService.cs
+++ b/Telemachus/src/KSPWebSocketService.cs
@@ -25,7 +25,7 @@ namespace Telemachus
         private IKSPAPI kspAPI = null;
         private Servers.AsynchronousServer.ClientConnection clientConnection = null;
 
-        private Regex matchJSONAttributes = new Regex(@"[\{""|,\s+""|,""]([^"":]*)"":([^:]*)[,|\}]");
+        private Regex matchJSONAttributes = new Regex(@"[\{\s*""|,\s*""|]([^"":]*)""\s*:\s*([^:]*)\s*[,|\}]");
 
         private Timer streamTimer = new Timer();
 


### PR DESCRIPTION
As per the JSON root documentation (http://json.org/ , specifically "Whitespace can be inserted between any pair of tokens") and the example at https://github.com/richardbunt/Telemachus/wiki/Web-Socket-API, extended the JSON parser to handle whitespace between any two JSON language tokens.

(Note: I lack a C# compiler and the toolchain for testing, so this is a blind change. Please verify before accepting).
