### PR TITLE
Fix issue #24: Corrected 500 crash in docking nodes.

### DIFF
--- a/Telemachus/src/DataLinkHandlers.cs
+++ b/Telemachus/src/DataLinkHandlers.cs
@@ -850,15 +850,12 @@ namespace Telemachus
         {
             ModuleDockingNode targetPort = null;
             Transform selfTransform = FlightGlobals.ActiveVessel.ReferenceTransform;
-            try
-            {
-                targetPort = FlightGlobals.fetch.VesselTarget as ModuleDockingNode;
-            }
-            catch
+            targetPort = FlightGlobals.fetch.VesselTarget as ModuleDockingNode;
+            if (targetPort == null)
             {
                 return;
             }
-
+            
             Transform targetTransform = targetPort.transform;
             Vector3 targetPortOutVector;
             Vector3 targetPortRollReferenceVector;


### PR DESCRIPTION
In C#, "foo = bar as Duck" will set foo to null if bar cannot downcast to type 'Duck'. This resulted in an attempt to manipulate the null pointer, resulting in an exception propagating to the handlers for dock.ax, dock.ay, and dock.az inputs if the user had selected a target ship but had not yet selected a docking port on the target ship.

This change should correct issue #24 
