### PR TITLE
Implement a third-party mod Plugin API

### DIFF
--- a/Telemachus/Telemachus.csproj
+++ b/Telemachus/Telemachus.csproj
@@ -62,6 +62,7 @@
     <Compile Include="src\IterationToEvent.cs" />
     <Compile Include="src\KSPWebSocketService.cs" />
     <Compile Include="src\PluginLogger.cs" />
+    <Compile Include="src\PluginRegistration.cs" />
     <Compile Include="src\SimpleJSON.cs" />
     <Compile Include="src\TelemachusBehaviour.cs" />
     <Compile Include="src\TelemachusPartModules.cs" />

--- a/Telemachus/src/DataLinkHandlers.cs
+++ b/Telemachus/src/DataLinkHandlers.cs
@@ -1889,27 +1889,6 @@ namespace Telemachus
         #endregion
     }
 
-    public class DefaultDataLinkHandler : DataLinkHandler
-    {
-        #region Initialisation
-
-        public DefaultDataLinkHandler(FormatterProvider formatters)
-            : base(formatters)
-        {
-        }
-
-        #endregion
-
-        #region DataLinkHandler
-
-        public override bool process(String API, out APIEntry result)
-        {
-            throw new Servers.MinimalHTTPServer.ExceptionResponsePage("Bad data link reference.");
-        }
-
-        #endregion
-    }
-
     public abstract class DataLinkHandler
     {
         #region API Delegates

--- a/Telemachus/src/DataLinkResponsibility.cs
+++ b/Telemachus/src/DataLinkResponsibility.cs
@@ -70,24 +70,29 @@ namespace Telemachus
                     PluginLogger.debug(e.Message + " " + e.StackTrace);
                 }
 
-                if (request.requestType == HTTPRequest.GET)
+                try {
+                    if (request.requestType == HTTPRequest.GET)
+                    {
+                        dataRates.addDownLinkPoint(
+                            System.DateTime.Now,
+                            ((Servers.MinimalHTTPServer.ClientConnection)cc).Send(new OKResponsePage(
+                                argumentsParse(request.path.Remove(0,
+                                    request.path.IndexOf(ARGUMENTS_START) + 1),
+                                    dataSources)
+                            )) * UpLinkDownLinkRate.BITS_PER_BYTE);
+                    }
+                    else if (request.requestType == HTTPRequest.POST)
+                    {
+                        dataRates.addDownLinkPoint(
+                            System.DateTime.Now,
+                            ((Servers.MinimalHTTPServer.ClientConnection)cc).Send(new OKResponsePage(
+                                argumentsParse(request.content,
+                                    dataSources)
+                            )) * UpLinkDownLinkRate.BITS_PER_BYTE);
+                    }
+                } catch (IKSPAPI.UnknownAPIException ex)
                 {
-                    dataRates.addDownLinkPoint(
-                        System.DateTime.Now,
-                        ((Servers.MinimalHTTPServer.ClientConnection)cc).Send(new OKResponsePage(
-                            argumentsParse(request.path.Remove(0,
-                                request.path.IndexOf(ARGUMENTS_START) + 1),
-                                dataSources)
-                        )) * UpLinkDownLinkRate.BITS_PER_BYTE);
-                }
-                else if (request.requestType == HTTPRequest.POST)
-                {
-                    dataRates.addDownLinkPoint(
-                        System.DateTime.Now,
-                        ((Servers.MinimalHTTPServer.ClientConnection)cc).Send(new OKResponsePage(
-                            argumentsParse(request.content,
-                                dataSources)
-                        )) * UpLinkDownLinkRate.BITS_PER_BYTE);
+                    throw new ExceptionResponsePage("Bad data link reference: " + ex.apiString);
                 }
 
                 return true;

--- a/Telemachus/src/DataLinkResponsibility.cs
+++ b/Telemachus/src/DataLinkResponsibility.cs
@@ -116,7 +116,6 @@ namespace Telemachus
 
         private String argumentsParse(String args, DataSources dataSources)
         {
-            APIEntry currentEntry = null;
             var APIResults = new Dictionary<string,object>();
             String[] argsSplit = args.Split(ARGUMENTS_DELIMETER);
 
@@ -124,31 +123,21 @@ namespace Telemachus
             {
                 string refArg = arg;
                 PluginLogger.fine(refArg);
-                kspAPI.parseParams(ref refArg, ref dataSources);
-                currentEntry = argumentParse(refArg, dataSources);
-                APIResults[dataSources.getVarName()] = currentEntry.formatter.prepareForSerialization(currentEntry.function(dataSources));
 
-                //Only parse the paused argument if the active vessel is null
-                if (dataSources.vessel == null)
-                {
-                    break;
-                }
+                var nameAndAPI = SplitQueryParams(arg);
+                APIResults[nameAndAPI.Key] = kspAPI.ProcessAPIString(nameAndAPI.Value);
             }
 
             return SimpleJson.SimpleJson.SerializeObject(APIResults);
         }
 
-        
-
-        private APIEntry argumentParse(String args, DataSources dataSources)
+        /// <summary>Splits and unescapes a URL query fragment in the form a=b into separate key and value</summary>
+        private static KeyValuePair<string,string> SplitQueryParams(string queryWithAssign)
         {
-            String[] argsSplit = args.Split(ARGUMENTS_ASSIGN);
-            APIEntry result = null;
-
-            kspAPI.process(argsSplit[1], out result);
-
-            dataSources.setVarName(argsSplit[0]);
-            return result;
+            string[] argsSplit = queryWithAssign.Split(ARGUMENTS_ASSIGN);
+            var keyName = UnityEngine.WWW.UnEscapeURL(argsSplit[0]);
+            var apiName = UnityEngine.WWW.UnEscapeURL(argsSplit[1]);
+            return new KeyValuePair<string, string>(keyName, apiName);
         }
 
         #endregion

--- a/Telemachus/src/KSPWebSocketService.cs
+++ b/Telemachus/src/KSPWebSocketService.cs
@@ -65,8 +65,6 @@ namespace Telemachus
                     {
                         var entries = new Dictionary<string,object>();
 
-                        APIEntry entry = null;
-
                         dataSources.vessel = kspAPI.getVessel();
 
                         //Only parse the paused argument if the active vessel is null
@@ -74,19 +72,12 @@ namespace Telemachus
                         {
                             toRun.UnionWith(subscriptions);
 
-                            foreach (string s in toRun)
+                            foreach (string s in toRun.Select(x => x.Trim()))
                             {
-                                DataSources dataSourcesClone = dataSources.Clone();
-                                string trimedQuotes = s.Trim();
-                                string refArg = trimedQuotes;
-                                kspAPI.parseParams(ref refArg, ref dataSourcesClone);
-
-                                kspAPI.process(refArg, out entry);
-
-                                if (entry != null)
+                                var result = kspAPI.ProcessAPIString(s);
+                                if (result != null)
                                 {
-                                    dataSourcesClone.setVarName(trimedQuotes);
-                                    entries[dataSourcesClone.getVarName()] = entry.formatter.prepareForSerialization(entry.function(dataSourcesClone));
+                                    entries[s] = result;
                                 }
                             }
 

--- a/Telemachus/src/PluginRegistration.cs
+++ b/Telemachus/src/PluginRegistration.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Telemachus
+{
+    using System.Text.RegularExpressions;
+    // Aliases for the important return types. This is so that the code is actually readable.
+    using APIDelegate = Func<Vessel, string[], object>;
+    using APIHandler = Func<string, Func<Vessel, string[], object>>;
+
+    /// <summary>
+    /// The public-facing, easy-to-access static face of the Telemachus plugin system.
+    /// </summary>
+    static class PluginRegistration
+    {
+        public static PluginManager Manager { get; set; }
+
+        public static Action Register(object toRegister)
+        {
+            if (Manager == null) throw new NullReferenceException("Telemachus Plugin infrastructure not yet intialised!");
+
+            return Manager.Register(toRegister);
+        }
+    }
+
+    public interface IMinimalTelemachusPlugin
+    {
+        /// <summary>
+        /// Gets a list of commands that the plugin responds to. This can include wildcards (*).
+        /// </summary>
+        string[] Commands { get; }
+        /// <summary>
+        /// Called to retrieve a delegate for calling a particular API, which 
+        /// </summary>
+        /// <param name="API"></param>
+        /// <returns></returns>
+        APIDelegate GetAPIHandler(string API);
+    }
+
+    public class PluginManager
+    {
+
+        /// <summary>
+        /// Records information about a particular plugin instance
+        /// </summary>
+        private class PluginHandler
+        {
+            public object instance = null;
+            public HashSet<string> commands = new HashSet<string>();
+            public List<Regex> regexCommands = new List<Regex>();
+            public APIHandler apiHandler = null;
+            // Set of handlers that we have already evaluated as coming from this plugin.
+            // Used in case we want to remove the plugin and clear out API entries.
+            public HashSet<string> known_handlers = new HashSet<string>();
+        }
+
+        // List of registered plugin instances
+        private List<PluginHandler> registeredPlugins = new List<PluginHandler>();
+        private Dictionary<string, APIDelegate> handlers = new Dictionary<string, APIDelegate>();
+        private object _dataLock = new object();
+
+        public PluginManager()
+        {
+            // Register ourselves if there is no other manager
+            if (PluginRegistration.Manager == null) PluginRegistration.Manager = this;
+        }
+
+        /// <summary>
+        /// Registers a plugin API with Telemachus
+        /// </summary>
+        /// <param name="toRegister">An instance of a Plugin object, that conforms to the TelemachusPlugin interface. 
+        /// NOTE: Does NOT have to be a physical instance of the interface.</param>
+        /// <returns>An Action, calling of which Deregisters the plugin. This is disposeable.</returns>
+        public Action Register(object toRegister)
+        {
+            var handler = new PluginHandler() { instance = toRegister };
+            // Get a list of commands that this instance handles
+            var commands = ReadCommandList(toRegister);
+            // Get the plugin handler function
+            var apiMethod = toRegister.GetType().GetMethod("GetAPIHandler", new Type[] { typeof(string) });
+            if (apiMethod.ReturnType != typeof(APIDelegate))
+                throw new ArgumentException("Telemachus could not find the API handler 'Func<Vessel, string[], object> GetAPIHandler(string)' on the provided interface");
+            handler.apiHandler = (APIHandler)Delegate.CreateDelegate(typeof(APIHandler), toRegister, apiMethod);
+            PluginLogger.print("Got plugin registration call for " + toRegister.GetType());
+
+            // Make a simple hashset of basic commands
+            handler.commands = new HashSet<string>(commands.Where(x => !x.Contains("*")));
+            // Now, deal with any wildcard plugin strings by building a regex
+            handler.regexCommands = commands
+                .Where(x => x.Contains("*"))
+                .Select(x => new Regex("^" + x.Replace(".", "\\.").Replace("*", ".*") + "$")).ToList();
+
+            lock(_dataLock)
+                registeredPlugins.Add(handler);
+
+            // Return a method to call to deregister this from the plugin system.
+            return () => { Deregister(handler); };
+        }
+
+        /// <summary>
+        /// Deregisters an API plugin handler instance via handler reference
+        /// </summary>
+        /// <param name="handler">The plugin handler for the plugin</param>
+        private void Deregister(PluginHandler handler)
+        {
+            PluginLogger.print("Removing registered plugin " + handler.instance.ToString());
+            // Remove the handler caches
+            lock(_dataLock)
+            {
+                foreach (var api in handler.known_handlers)
+                {
+                    handlers.Remove(api);
+                }
+                registeredPlugins.Remove(handler);
+            }
+        }
+
+        private static string[] ReadCommandList(object pluginInstance)
+        {
+            var objType = pluginInstance.GetType();
+            object returnValue = null;
+
+            // Attempt to read from either a property, or a field, or a member function, named 'Commands'
+            var prop = objType.GetProperty("Commands");
+            var field = objType.GetField("Commands");
+            var method = objType.GetMethod("Commands");
+            if (prop != null)
+            {
+                returnValue = prop.GetValue(pluginInstance, null);
+            }
+            else if (field != null)
+            {
+                returnValue = field.GetValue(pluginInstance);
+            }
+            else if (method != null && method.ReturnType != typeof(void) && method.GetParameters().Length == 0)
+            {
+                returnValue = method.Invoke(pluginInstance, null);
+            }
+            // Did we read anything?
+            if (returnValue == null) throw new ArgumentException("Telemachus could not read 'Commands' member from object " + pluginInstance.ToString());
+
+            // Now, determine the type, and return the command list.
+            if (returnValue is string)
+            {
+                return new string[] { (string)returnValue };
+            }
+            else if (returnValue is IEnumerable)
+            {
+                return ((IEnumerable)returnValue).OfType<string>().ToArray();
+            }
+            // Unrecognised format.
+            throw new ArgumentException("Telemachus got unknown type '" + returnValue.GetType().ToString() + "' as Command list, expecting string[]");
+        }
+
+        /// <summary>
+        /// Scans the registered plugins for one that handles the named API string
+        /// </summary>
+        /// <param name="APIname">The API string to handle, excluding any parameters</param>
+        /// <returns>An API-processing delegate, or null if none were found</returns>
+        public APIDelegate GetAPIDelegate(string APIname)
+        {
+            lock(_dataLock)
+            {
+                // Check our handler cache first.
+                if (handlers.ContainsKey(APIname))
+                {
+                    return handlers[APIname];
+                }
+                foreach (var plugin in registeredPlugins)
+                {
+                    // Does this match the api at all?
+                    if (plugin.commands.Contains(APIname) || plugin.regexCommands.Any(x => x.IsMatch(APIname)))
+                    {
+                        try
+                        {
+                            var del = plugin.apiHandler(APIname);
+                            if (del != null)
+                            {
+                                // Add to the handling cache and the plugin response list
+                                handlers[APIname] = del;
+                                plugin.known_handlers.Add(APIname);
+                                return del;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            PluginLogger.print("Got Exception processing plugin " + plugin.instance.ToString() + ", " + ex.ToString());
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/Telemachus/src/PluginRegistration.cs
+++ b/Telemachus/src/PluginRegistration.cs
@@ -89,7 +89,10 @@ namespace Telemachus
         {
             var pluginType = toRegister.GetType();
             // Must conform at least to the minimal interface
-            if (!pluginType.DoesMatchInterfaceOf(typeof(IMinimalTelemachusPlugin))) throw new ArgumentException("Object " + toRegister.GetType().ToString() + " does not conform to the minimal interface");
+            if (!typeof(IMinimalTelemachusPlugin).IsAssignableFrom(pluginType) && !pluginType.DoesMatchInterfaceOf(typeof(IMinimalTelemachusPlugin)))
+            {
+                throw new ArgumentException("Object " + toRegister.GetType().ToString() + " does not conform to the minimal interface");
+            }
 
             var handler = new PluginHandler() { instance = toRegister };
             // Get a list of commands that this instance handles
@@ -99,7 +102,7 @@ namespace Telemachus
             handler.apiHandler = (APIHandler)Delegate.CreateDelegate(typeof(APIHandler), toRegister, apiMethod);
 
             // Does it match the Deregistration? If so, pass it the deregistration method
-            if (pluginType.DoesMatchInterfaceOf(typeof(IDeregisterableTelemachusPlugin)))
+            if (toRegister is IDeregisterableTelemachusPlugin || pluginType.DoesMatchInterfaceOf(typeof(IDeregisterableTelemachusPlugin)))
             {
                 Action deregistration = () => Deregister(handler);
                 pluginType.GetProperty("Deregister").SetValue(toRegister, deregistration, null);

--- a/Telemachus/src/TelemachusBehaviour.cs
+++ b/Telemachus/src/TelemachusBehaviour.cs
@@ -303,6 +303,23 @@ namespace Telemachus
         {
             return FlightGlobals.ActiveVessel;
         }
+
+        public override object ProcessAPIString(string apistring)
+        {
+            var data = new DataSources() { vessel = getVessel() };
+            // Extract any arguments/parameters in this API string
+            var name = apistring;
+            parseParams(ref name, ref data);
+            // Get the API entry
+            APIEntry apiEntry = null;
+            process(name, out apiEntry);
+            if (apiEntry == null) return null;
+            
+            // run the API entry
+            var result = apiEntry.function(data);
+            // And return the serialization-ready value
+            return apiEntry.formatter.prepareForSerialization(result);
+        }
     }
 
     public abstract class IKSPAPI
@@ -372,5 +389,13 @@ namespace Telemachus
                 PluginLogger.debug(e.Message + " " + e.StackTrace);
             }
         }
+
+        /// <summary>
+        /// Accepts a string, and does any API processing (with the current vessel), returning the result.
+        /// </summary>
+        /// <remarks>This take responsibility for the whole chain of parsing, splitting and searching for the API</remarks>
+        /// <param name="apistring"></param>
+        /// <returns></returns>
+        public abstract object ProcessAPIString(string apistring);
     }
 }

--- a/Telemachus/src/TelemachusBehaviour.cs
+++ b/Telemachus/src/TelemachusBehaviour.cs
@@ -295,8 +295,6 @@ namespace Telemachus
                     new DockingDataLinkHandler(formatters)
                     }, formatters
                 ));
-
-            APIHandlers.Add(new DefaultDataLinkHandler(formatters));
         }
 
         public override Vessel getVessel()
@@ -324,6 +322,29 @@ namespace Telemachus
 
     public abstract class IKSPAPI
     {
+        public class UnknownAPIException : ArgumentException
+        {
+            public string apiString = "";
+
+            public UnknownAPIException(string apiString = "")
+            {
+                this.apiString = apiString;
+            }
+
+            public UnknownAPIException(string message, string apiString = "")
+                : base(message)
+            {
+                this.apiString = apiString;
+            }
+
+            public UnknownAPIException(string message, string apiString, Exception inner)
+                : base(message, inner)
+            {
+                this.apiString = apiString;
+            }
+        }
+
+
         protected List<DataLinkHandler> APIHandlers = new List<DataLinkHandler>();
 
         public void getAPIList(ref List<APIEntry> APIList)
@@ -359,7 +380,7 @@ namespace Telemachus
                     break;
                 }
             }
-
+            if (result == null) throw new UnknownAPIException("Could not find API entry named " + API, API);
             apiEntry = result;
         }
 

--- a/TelemachusTest/src/DummyKSPAPI.cs
+++ b/TelemachusTest/src/DummyKSPAPI.cs
@@ -18,6 +18,11 @@ namespace TelemachusTest
         {
             return null;
         }
+
+        public override object ProcessAPIString(string apistring)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class DummyHandler : DataLinkHandler

--- a/TelemachusTest/src/GenerateAPIDocumentation.cs
+++ b/TelemachusTest/src/GenerateAPIDocumentation.cs
@@ -21,7 +21,7 @@ namespace TelemachusTest
         {
             Servers.AsynchronousServer.ServerConfiguration config = new Servers.AsynchronousServer.ServerConfiguration();
             Telemachus.VesselChangeDetector vesselChangeDetector = new Telemachus.VesselChangeDetector(false);
-            Telemachus.KSPAPI api = new Telemachus.KSPAPI(Telemachus.JSONFormatterProvider.Instance, vesselChangeDetector, config);
+            Telemachus.KSPAPI api = new Telemachus.KSPAPI(Telemachus.JSONFormatterProvider.Instance, vesselChangeDetector, config, null);
 
             List<Telemachus.APIEntry> apiList = new List<Telemachus.APIEntry>();
             api.getAPIList(ref apiList);


### PR DESCRIPTION
I've implemented a Plugin API so that other mods can register API strings with Telemachus, without needing to link directly to. I'm not sure I expect a direct merge but certainly worth looking at for direction. Sorry to push more changes on you when I know you have limited time at the moment, but this still isn't the half of it :stuck_out_tongue_winking_eye: (that would be the currently-WIP-moving-target of [this](https://github.com/richardbunt/Telemachus/compare/master...ndevenish:wsredo))

This pull request is a little noisy as it depends on a couple of my previous/cleanup commits, that aren't merged now/yet; namely:
* SimpleJSON serialization
* Cleanup of the API processing (down to a single call on IKSPAPI rather than several)
* Let the regular processing throw an exception when nothing results - this removes the need for the `DefaultFormatter`, which stops anything after it from processing.

Apart from that, the entirety of the plugin changes are in fa03c000ff5c5f6489535caf9e54fc7deacfe313, so that's the main thing to focus on. I've written a documentation page explaining how to use it here: https://github.com/ndevenish/Telemachus/wiki/Writing-a-Telemachus-Plugin. Essentially, I've gone with requiring them to call via reflection a registration function (the other option would be some kind of scanning for named/particular classes, which seems *too* magical, and inflexible). Several callbacks on the instance they pass in are then called to get details on the API strings, get the handlers etc. It lets the plugin instances register for wildcards, but since the internal ones always get processed first, I don't see a problem with that (and is more flexible anyway!).