### PR TITLE
Fixed staging for 1.1

### DIFF
--- a/Telemachus/src/DataLinkHandlers.cs
+++ b/Telemachus/src/DataLinkHandlers.cs
@@ -7,6 +7,7 @@ using Servers.AsynchronousServer;
 using System.Threading;
 using System.Collections;
 using UnityEngine;
+using KSP.UI.Screens;
 
 namespace Telemachus
 {
@@ -444,7 +445,7 @@ namespace Telemachus
                 dataSources =>
                 {
                     TelemachusBehaviour.instance.BroadcastMessage("queueDelayedAPI", new DelayedAPIEntry(dataSources.Clone(),
-                        (x) => { Staging.ActivateNextStage(); return 0d; }), UnityEngine.SendMessageOptions.DontRequireReceiver);
+                        (x) => { StageManager.ActivateNextStage(); return 0d; }), UnityEngine.SendMessageOptions.DontRequireReceiver);
                     return predictFailure(dataSources.vessel);
                 }, "f.stage", "Stage", formatters.Default));
 


### PR DESCRIPTION
Made the change necessary for staging to work in KSP1.1. I (lightly) tested out Telemachus with the new 1.1 build that was put out recently, and I found that the stage button was broken, nothing else was immediately noticeable. So, here is the fix.