### PR TITLE
Update IOPageResponsibility.cs (adding .mp4,.json and .txt MIME types/support)

### DIFF
--- a/Telemachus/src/IOPageResponsibility.cs
+++ b/Telemachus/src/IOPageResponsibility.cs
@@ -86,6 +86,9 @@ namespace Telemachus
                 contentTypes[".ttf"] = new HTMLResponseContentType { contentType = HTMLContentType.BinaryContent, mimeType = "application/font-sfnt" };
                 contentTypes[".woff"] = new HTMLResponseContentType { contentType = HTMLContentType.BinaryContent, mimeType = "application/font-woff" };
                 contentTypes[".otf"] = new HTMLResponseContentType { contentType = HTMLContentType.BinaryContent, mimeType = "application/font-sfnt" };
+                contentTypes[".mp4"] = new HTMLResponseContentType { contentType = HTMLContentType.BinaryContent, mimeType = "video/mp4" };
+                contentTypes[".json"] = new HTMLResponseContentType { contentType = HTMLContentType.BinaryContent, mimeType = "application/json" };
+                contentTypes[".txt"] = new HTMLResponseContentType { contentType = HTMLContentType.BinaryContent, mimeType = "text/plain" };
                 contentTypes[""] = new HTMLResponseContentType { contentType = HTMLContentType.BinaryContent, mimeType = null };
 
             }


### PR DESCRIPTION
Adding .mp4, .json, and .txt for add-on mod support (ie. KSP PAO). Allows for mp4 video files, json data and txt files to used internally or externally with Telemachus interface.